### PR TITLE
Remove updatedAt for the repository UI

### DIFF
--- a/web/src/features/main/Repository.tsx
+++ b/web/src/features/main/Repository.tsx
@@ -17,21 +17,11 @@ export function Repository(props: RepositoryProps) {
                 <Chip label={repository.accessMode} variant={"outlined"} color={"secondary"} size={"small"}/>
             </Stack>
             <Box>
-                {(() => {
-                    if (repository.description?.length === undefined) {
-                        return null
-                    }
-                    return (
-                        <Typography variant={"body2"}>
-                            {repository.description}
-                        </Typography>
-                    )
-                })()}
-            </Box>
-            <Box>
-                <Typography variant={"body2"}>
-                    updated today
-                </Typography>
+                {repository.description?.length &&
+                    <Typography variant={"body2"}>
+                        {repository.description}
+                    </Typography>
+                }
             </Box>
         </Stack>
     )


### PR DESCRIPTION
Remove it because in the current backend structure it's very hard to add the correct representation of `updatedAt` field for the repo